### PR TITLE
Fix dependency versions for Vercel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/node_modules/
+**/dist/
+package-lock.json

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@starknet-react/core": "^1.0.6",
-    "starknet": "^5.5.0"
+    "@starknet-react/core": "^3.7.4",
+    "starknet": "^6.24.1"
   },
   "devDependencies": {
     "vite": "^4.4.0",


### PR DESCRIPTION
## Summary
- add gitignore for build artifacts and lock file
- upgrade starknet react dependencies so `npm install` succeeds

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884bbfe3d708321b93002f38061c6e5